### PR TITLE
Obj.update

### DIFF
--- a/store/schema.test.ts
+++ b/store/schema.test.ts
@@ -4,6 +4,8 @@ import { configureStore } from "./store.ts";
 import { slice } from "./slice/mod.ts";
 import { createSchema } from "./schema.ts";
 
+import { app } from "./test.util.ts"
+import { updateStore } from "./mod.ts";
 const tests = describe("createSchema()");
 
 interface User {
@@ -89,5 +91,19 @@ it(tests, "can work with a nested object", async () => {
     yield* schema.update(db.currentUser.patch({ key: "roles", value: ["admin", "user"] }));
     const curUser3 = yield* select(db.currentUser.select);
     asserts.assertEquals(curUser3, { id: "", name: "vvv", roles: ["admin", "user"] });
+  });
+});
+
+it(tests, "can use an imported object for the schema definition", async () => {
+  const schema = createSchema({
+    [app.repoName]: slice.obj<typeof app>(app),
+  });
+  const db = schema.db;
+  const store = await configureStore(schema);
+  
+  await store.run(function* () {
+    yield* updateStore(db.app.patch({ key: "thisAppVersion", value: "2.0.0" }));
+    const app = yield* select(db.app.select);
+    asserts.assertEquals(app, { repoName:"app", thisAppName: "my-app", thisAppVersion: "2.0.0" });
   });
 });

--- a/store/schema.test.ts
+++ b/store/schema.test.ts
@@ -4,7 +4,7 @@ import { configureStore } from "./store.ts";
 import { slice } from "./slice/mod.ts";
 import { createSchema } from "./schema.ts";
 
-import { app } from "./test.util.ts"
+import { app } from "./test.util.ts";
 import { updateStore } from "./mod.ts";
 const tests = describe("createSchema()");
 
@@ -38,7 +38,7 @@ it(tests, "general types and functionality", async () => {
     counter: 0,
     dev: false,
     currentUser: { id: "", name: "" },
-    loaders: {}
+    loaders: {},
   });
   const userMap = schema.db.users.selectTable(store.getState());
   asserts.assertEquals(userMap, { "1": { id: "1", name: "wow" } });
@@ -59,7 +59,7 @@ it(tests, "general types and functionality", async () => {
     const counter = yield* select(db.counter.select);
     asserts.assertEquals(counter, 1);
 
-    yield* schema.update(db.currentUser.patch({ key: "name", value: "vvv" }));
+    yield* schema.update(db.currentUser.update({ key: "name", value: "vvv" }));
     const curUser = yield* select(db.currentUser.select);
     asserts.assertEquals(curUser, { id: "", name: "vvv" });
 
@@ -75,22 +75,30 @@ it(tests, "general types and functionality", async () => {
 
 it(tests, "can work with a nested object", async () => {
   const schema = createSchema({
-    currentUser : slice.obj<UserWithRoles>({ id: "", name: "", roles: [] }),
+    currentUser: slice.obj<UserWithRoles>({ id: "", name: "", roles: [] }),
   });
   const db = schema.db;
   const store = configureStore(schema);
   await store.run(function* () {
-    yield* schema.update(db.currentUser.patch({ key: "name", value: "vvv" }));
+    yield* schema.update(db.currentUser.update({ key: "name", value: "vvv" }));
     const curUser = yield* select(db.currentUser.select);
     asserts.assertEquals(curUser, { id: "", name: "vvv", roles: [] });
 
-    yield* schema.update(db.currentUser.patch({ key: "roles", value: ["admin"] }));
+    yield* schema.update(
+      db.currentUser.update({ key: "roles", value: ["admin"] }),
+    );
     const curUser2 = yield* select(db.currentUser.select);
     asserts.assertEquals(curUser2, { id: "", name: "vvv", roles: ["admin"] });
 
-    yield* schema.update(db.currentUser.patch({ key: "roles", value: ["admin", "user"] }));
+    yield* schema.update(
+      db.currentUser.update({ key: "roles", value: ["admin", "user"] }),
+    );
     const curUser3 = yield* select(db.currentUser.select);
-    asserts.assertEquals(curUser3, { id: "", name: "vvv", roles: ["admin", "user"] });
+    asserts.assertEquals(curUser3, {
+      id: "",
+      name: "vvv",
+      roles: ["admin", "user"],
+    });
   });
 });
 
@@ -100,10 +108,16 @@ it(tests, "can use an imported object for the schema definition", async () => {
   });
   const db = schema.db;
   const store = await configureStore(schema);
-  
+
   await store.run(function* () {
-    yield* updateStore(db.app.patch({ key: "thisAppVersion", value: "2.0.0" }));
+    yield* updateStore(
+      db.app.update({ key: "thisAppVersion", value: "2.0.0" }),
+    );
     const app = yield* select(db.app.select);
-    asserts.assertEquals(app, { repoName:"app", thisAppName: "my-app", thisAppVersion: "2.0.0" });
+    asserts.assertEquals(app, {
+      repoName: "app",
+      thisAppName: "my-app",
+      thisAppVersion: "2.0.0",
+    });
   });
 });

--- a/store/slice/obj.test.ts
+++ b/store/slice/obj.test.ts
@@ -1,0 +1,77 @@
+import { asserts, describe, it } from "../../test.ts";
+import { configureStore, updateStore } from "../../store/mod.ts";
+
+import { createObj } from "./obj.ts";
+const tests = describe("createObj()");
+
+export type TCurrentUser = {
+	username: string;
+	userId: number;
+	isadmin: boolean;
+	roles: string[];
+};
+
+const NAME = "currentUser";
+const crtInitialState = {
+	username: "",
+	userId: 0,
+	isadmin: false,
+	roles: [],
+}
+
+const slice = createObj<TCurrentUser>({
+	name: NAME,
+	initialState: crtInitialState,
+});
+
+Deno.test( "sets up an obj", async () => {
+	const store = configureStore({
+		initialState: {
+			[NAME]: crtInitialState,
+		},
+	});
+	
+	await store.run(function* () {
+
+		yield* updateStore(slice.set({ 
+			username: "bob", 
+			userId: 1,
+			isadmin: true,
+			roles: ["admin", "user"],
+		}));
+
+	});
+
+	asserts.assertEquals(store.getState()['currentUser'], { 
+		username: "bob",
+		userId: 1,
+		isadmin: true,
+		roles: ["admin", "user"]
+	 });
+	
+
+	await store.run(function* () {
+
+		yield* updateStore(slice.patch({ key: "username", value: "alice" }));
+	});
+	
+	asserts.assertEquals(store.getState()['currentUser'], {
+		username: "alice",
+		userId: 1,
+		isadmin: true,
+		roles: ["admin", "user"]
+	});
+
+	await store.run(function* () {
+
+		yield* updateStore(slice.patch({ key: "roles", value: ["admin", "superuser"] }));
+	});
+
+	asserts.assertEquals(store.getState()['currentUser'], {
+		username: "alice",
+		userId: 1,
+		isadmin: true,
+		roles: ["admin", "superuser"]
+	});
+});
+

--- a/store/slice/obj.test.ts
+++ b/store/slice/obj.test.ts
@@ -5,73 +5,69 @@ import { createObj } from "./obj.ts";
 const tests = describe("createObj()");
 
 export type TCurrentUser = {
-	username: string;
-	userId: number;
-	isadmin: boolean;
-	roles: string[];
+  username: string;
+  userId: number;
+  isadmin: boolean;
+  roles: string[];
 };
 
 const NAME = "currentUser";
 const crtInitialState = {
-	username: "",
-	userId: 0,
-	isadmin: false,
-	roles: [],
-}
+  username: "",
+  userId: 0,
+  isadmin: false,
+  roles: [],
+};
 
 const slice = createObj<TCurrentUser>({
-	name: NAME,
-	initialState: crtInitialState,
+  name: NAME,
+  initialState: crtInitialState,
 });
 
-Deno.test( "sets up an obj", async () => {
-	const store = configureStore({
-		initialState: {
-			[NAME]: crtInitialState,
-		},
-	});
-	
-	await store.run(function* () {
+it(tests, "sets up an obj", async () => {
+  const store = configureStore({
+    initialState: {
+      [NAME]: crtInitialState,
+    },
+  });
 
-		yield* updateStore(slice.set({ 
-			username: "bob", 
-			userId: 1,
-			isadmin: true,
-			roles: ["admin", "user"],
-		}));
+  await store.run(function* () {
+    yield* updateStore(slice.set({
+      username: "bob",
+      userId: 1,
+      isadmin: true,
+      roles: ["admin", "user"],
+    }));
+  });
 
-	});
+  asserts.assertEquals(store.getState()["currentUser"], {
+    username: "bob",
+    userId: 1,
+    isadmin: true,
+    roles: ["admin", "user"],
+  });
 
-	asserts.assertEquals(store.getState()['currentUser'], { 
-		username: "bob",
-		userId: 1,
-		isadmin: true,
-		roles: ["admin", "user"]
-	 });
-	
+  await store.run(function* () {
+    yield* updateStore(slice.update({ key: "username", value: "alice" }));
+  });
 
-	await store.run(function* () {
+  asserts.assertEquals(store.getState()["currentUser"], {
+    username: "alice",
+    userId: 1,
+    isadmin: true,
+    roles: ["admin", "user"],
+  });
 
-		yield* updateStore(slice.patch({ key: "username", value: "alice" }));
-	});
-	
-	asserts.assertEquals(store.getState()['currentUser'], {
-		username: "alice",
-		userId: 1,
-		isadmin: true,
-		roles: ["admin", "user"]
-	});
+  await store.run(function* () {
+    yield* updateStore(
+      slice.update({ key: "roles", value: ["admin", "superuser"] }),
+    );
+  });
 
-	await store.run(function* () {
-
-		yield* updateStore(slice.patch({ key: "roles", value: ["admin", "superuser"] }));
-	});
-
-	asserts.assertEquals(store.getState()['currentUser'], {
-		username: "alice",
-		userId: 1,
-		isadmin: true,
-		roles: ["admin", "superuser"]
-	});
+  asserts.assertEquals(store.getState()["currentUser"], {
+    username: "alice",
+    userId: 1,
+    isadmin: true,
+    roles: ["admin", "superuser"],
+  });
 });
-

--- a/store/slice/obj.ts
+++ b/store/slice/obj.ts
@@ -8,7 +8,7 @@ export interface ObjOutput<V extends AnyState, S extends AnyState>
   initialState: V;
   set: (v: V) => (s: S) => void;
   reset: () => (s: S) => void;
-  patch: <P extends keyof V>(prop: { key: P; value: V[P] }) => (s: S) => void;
+  update: <P extends keyof V>(prop: { key: P; value: V[P] }) => (s: S) => void;
   select: (s: S) => V;
 }
 
@@ -27,7 +27,7 @@ export function createObj<V extends AnyState, S extends AnyState = AnyState>(
       // deno-lint-ignore no-explicit-any
       (state as any)[name] = initialState;
     },
-    patch: <P extends keyof V>(prop: { key: P; value: V[P] }) => (state) => {
+    update: <P extends keyof V>(prop: { key: P; value: V[P] }) => (state) => {
       // deno-lint-ignore no-explicit-any
       (state as any)[name][prop.key] = prop.value;
     },

--- a/store/test.util.ts
+++ b/store/test.util.ts
@@ -1,5 +1,5 @@
 export const app = {
-	repoName: 'app',
-    thisAppName: "my-app",
-    thisAppVersion: "1.0.0",
-  }
+  repoName: "app",
+  thisAppName: "my-app",
+  thisAppVersion: "1.0.0",
+};

--- a/store/test.util.ts
+++ b/store/test.util.ts
@@ -1,0 +1,5 @@
+export const app = {
+	repoName: 'app',
+    thisAppName: "my-app",
+    thisAppVersion: "1.0.0",
+  }


### PR DESCRIPTION
Proposing a rename from `obj.patch` to `obj.update` to prevent confusion with `table.patch`, which has a distinct signature. Additionally, including a few tests