### PR TITLE
feat: add custom transform functions for state persistence

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -3,7 +3,7 @@
     "types": "deno run --allow-write ./api-type-template.ts",
     "npm": "deno run -A ./npm.ts",
     "test": "deno test --allow-env --allow-read",
-    "test-filter" : "deno test --allow-env --allow-read --filter",
+    "test-filter": "deno test --allow-env --allow-read --filter",
     "sync-build-to": "deno run -A ./scripts/sync.ts"
   },
   "lint": {

--- a/deno.json
+++ b/deno.json
@@ -3,6 +3,7 @@
     "types": "deno run --allow-write ./api-type-template.ts",
     "npm": "deno run -A ./npm.ts",
     "test": "deno test --allow-env --allow-read",
+    "test-filter" : "deno test --allow-env --allow-read --filter",
     "sync-build-to": "deno run -A ./scripts/sync.ts"
   },
   "lint": {

--- a/deno.json
+++ b/deno.json
@@ -3,7 +3,6 @@
     "types": "deno run --allow-write ./api-type-template.ts",
     "npm": "deno run -A ./npm.ts",
     "test": "deno test --allow-env --allow-read",
-    "test-filter": "deno test --allow-env --allow-read --filter",
     "sync-build-to": "deno run -A ./scripts/sync.ts"
   },
   "lint": {

--- a/store/persist.ts
+++ b/store/persist.ts
@@ -1,6 +1,5 @@
-import { call, Err, Ok, Operation, Result } from "../deps.ts";
-import { safe } from "../mod.ts";
-import { select, updateStore } from "./fx.ts";
+import { call, Err, Ok, Operation, Result } from '../deps.ts';
+import { select, updateStore } from './fx.ts';
 
 import type { AnyState, Next } from "../types.ts";
 import type { UpdaterCtx } from "./types.ts";

--- a/store/persist.ts
+++ b/store/persist.ts
@@ -1,4 +1,4 @@
-import { call, Callable, Err, Ok, Operation, Result, sleep } from '../deps.ts';
+import { call, Err, Ok, Operation, Result } from '../deps.ts';
 import { select, updateStore } from './fx.ts';
 
 import type { AnyState, Next } from "../types.ts";

--- a/store/persist.ts
+++ b/store/persist.ts
@@ -1,6 +1,7 @@
-import { Err, Ok, type Operation, type Result } from "../deps.ts";
+import { Err, Ok, Operation, Result } from '../deps.ts';
+import { select, updateStore } from './fx.ts';
+
 import type { AnyState, Next } from "../types.ts";
-import { select, updateStore } from "./fx.ts";
 import type { UpdaterCtx } from "./types.ts";
 
 export const PERSIST_LOADER_ID = "@@starfx/persist";
@@ -17,7 +18,45 @@ export interface PersistProps<S extends AnyState> {
   key: string;
   reconciler: (original: S, rehydrated: Partial<S>) => S;
   rehydrate: () => Operation<Result<unknown>>;
+  transform?: Transform<S>;
 }
+
+class Transform<S extends AnyState> {
+  private defaults: Partial<S>;
+  public transformers: {
+    in: (state: S) => Partial<S>;
+    out: (state: S) => Partial<S>;
+  };
+
+  constructor(state: Partial<S>) {
+    this.defaults = state;
+    this.transformers = {
+      in: (_: S): Partial<S> => state,
+      out: (_: S): Partial<S> => state
+    };
+  }
+
+  in(state: S): Partial<S> {
+    return this.transformers.in(state);
+  }
+
+  out(state: S): Partial<S> {
+    return this.transformers.out(state);
+  }
+
+  setInTransformer(transformer: (state: S) => Partial<S>): void {
+    this.transformers.in = transformer;
+  }
+
+  setOutTransformer(transformer: (state: S) => Partial<S>): void {
+    this.transformers.out = transformer;
+  }
+}
+
+export function createTransform<S extends AnyState>(state: Partial<S>): Transform<S> {
+  return new Transform(state);
+}
+
 
 export function createLocalStorageAdapter<S extends AnyState>(): PersistAdapter<
   S
@@ -51,7 +90,7 @@ export function shallowReconciler<S extends AnyState>(
 }
 
 export function createPersistor<S extends AnyState>(
-  { adapter, key = "starfx", reconciler = shallowReconciler, allowlist = [] }:
+  { adapter, key = "starfx", reconciler = shallowReconciler, allowlist = [], transform }:
     & Pick<PersistProps<S>, "adapter">
     & Partial<PersistProps<S>>,
 ): PersistProps<S> {
@@ -60,9 +99,14 @@ export function createPersistor<S extends AnyState>(
     if (!persistedState.ok) {
       return Err(persistedState.error);
     }
+    let stateFromStorage = persistedState.value as Partial<S>;
+
+    if (transform) {
+      stateFromStorage = transform.out(stateFromStorage as S);
+    }
 
     const state = yield* select((s) => s);
-    const nextState = reconciler(state as S, persistedState.value);
+    const nextState = reconciler(state as S, stateFromStorage);
     yield* updateStore<S>(function (state) {
       Object.keys(nextState).forEach((key: keyof S) => {
         state[key] = nextState[key];
@@ -78,25 +122,35 @@ export function createPersistor<S extends AnyState>(
     allowlist,
     reconciler,
     rehydrate,
+    transform
   };
 }
 
 export function persistStoreMdw<S extends AnyState>(
-  { allowlist, adapter, key }: PersistProps<S>,
+  { allowlist, adapter, key, transform }: PersistProps<S>,
 ) {
   return function* (_: UpdaterCtx<S>, next: Next) {
     yield* next();
     const state = yield* select((s: S) => s);
+
+    let transformedState: Partial<S> = state;
+    if (transform) {
+      transformedState = transform.in(state);
+    }
+
     // empty allowlist list means save entire state
     if (allowlist.length === 0) {
-      yield* adapter.setItem(key, state);
+      yield* adapter.setItem(key, transformedState);
       return;
     }
 
     const allowedState = allowlist.reduce<Partial<S>>((acc, key) => {
-      acc[key] = state[key];
+      if (key in transformedState) {
+        acc[key] = transformedState[key] as S[keyof S];
+      }
       return acc;
     }, {});
+
     yield* adapter.setItem(key, allowedState);
   };
 }

--- a/store/persist.ts
+++ b/store/persist.ts
@@ -22,8 +22,8 @@ export interface PersistProps<S extends AnyState> {
 }
 
 interface TransformFunctions<S extends AnyState> {
-  in(s:Partial<S>): Operation<Partial<S>>;
-  out(s: Partial<S>):Operation<Partial<S>>;
+  in(s: Partial<S>): Operation<Partial<S>>;
+  out(s: Partial<S>): Operation<Partial<S>>;
 }
 
 export function createTransform<S extends AnyState>(initialState: Partial<S>) {
@@ -41,17 +41,17 @@ export function createTransform<S extends AnyState>(initialState: Partial<S>) {
   const setInTransformer = function (transformer: (fn: Partial<S>) => Operation<Partial<S>>): void {
     transformers.in = transformer;
   };
-  const setOutTransformer = function(transformer: (fn: Partial<S>) => Operation<Partial<S>>): void {
+  const setOutTransformer = function (transformer: (fn: Partial<S>) => Operation<Partial<S>>): void {
     transformers.out = transformer;
   };
 
   const inTransformer = function* (state: Partial<S>): Operation<Partial<S>> {
-    const result =  yield* transformers.in(state);
+    const result = yield* transformers.in(state);
     return result;
   };
 
   const outTransformer = function* (state: Partial<S>): Operation<Partial<S>> {
-    const result =  yield* transformers.out(state);
+    const result = yield* transformers.out(state);
     return result;
   };
 
@@ -106,7 +106,7 @@ export function createPersistor<S extends AnyState>(
     let stateFromStorage = persistedState.value as Partial<S>;
 
     if (transform) {
-      stateFromStorage = yield* call(()=> transform.out(stateFromStorage));
+      stateFromStorage = yield* call(() => transform.out(stateFromStorage));
     }
 
     const state = yield* select((s) => s);
@@ -139,7 +139,7 @@ export function persistStoreMdw<S extends AnyState>(
 
     let transformedState: Partial<S> = state;
     if (transform) {
-      transformedState =yield* call(transform.in(state));
+      transformedState = yield* call(transform.in(state));
     }
 
     // empty allowlist list means save entire state

--- a/store/persist.ts
+++ b/store/persist.ts
@@ -1,5 +1,5 @@
-import { call, Err, Ok, Operation, Result } from '../deps.ts';
-import { select, updateStore } from './fx.ts';
+import { call, Err, Ok, Operation, Result } from "../deps.ts";
+import { select, updateStore } from "./fx.ts";
 
 import type { AnyState, Next } from "../types.ts";
 import type { UpdaterCtx } from "./types.ts";
@@ -26,21 +26,23 @@ interface TransformFunctions<S extends AnyState> {
   out(s: Partial<S>): Operation<Partial<S>>;
 }
 
-export function createTransform<S extends AnyState>(inputState: Partial<S>) {
-
+export function createTransform<S extends AnyState>() {
   const transformers: TransformFunctions<S> = {
     in: function* (currentState: Partial<S>): Operation<Partial<S>> {
       return currentState;
-
     },
     out: function* (currentState: Partial<S>): Operation<Partial<S>> {
       return currentState;
-    }
+    },
   };
-  const setInTransformer = function (transformer: (fn: Partial<S>) => Operation<Partial<S>>): void {
+  const setInTransformer = function (
+    transformer: (fn: Partial<S>) => Operation<Partial<S>>,
+  ): void {
     transformers.in = transformer;
   };
-  const setOutTransformer = function (transformer: (fn: Partial<S>) => Operation<Partial<S>>): void {
+  const setOutTransformer = function (
+    transformer: (fn: Partial<S>) => Operation<Partial<S>>,
+  ): void {
     transformers.out = transformer;
   };
 
@@ -93,7 +95,13 @@ export function shallowReconciler<S extends AnyState>(
 }
 
 export function createPersistor<S extends AnyState>(
-  { adapter, key = "starfx", reconciler = shallowReconciler, allowlist = [], transform }:
+  {
+    adapter,
+    key = "starfx",
+    reconciler = shallowReconciler,
+    allowlist = [],
+    transform,
+  }:
     & Pick<PersistProps<S>, "adapter">
     & Partial<PersistProps<S>>,
 ): PersistProps<S> {
@@ -125,7 +133,7 @@ export function createPersistor<S extends AnyState>(
     allowlist,
     reconciler,
     rehydrate,
-    transform
+    transform,
   };
 }
 

--- a/store/persist.ts
+++ b/store/persist.ts
@@ -1,6 +1,6 @@
-import { call, Err, Ok, Operation, Result } from '../deps.ts';
-import { safe } from '../mod.ts';
-import { select, updateStore } from './fx.ts';
+import { call, Err, Ok, Operation, Result } from "../deps.ts";
+import { safe } from "../mod.ts";
+import { select, updateStore } from "./fx.ts";
 
 import type { AnyState, Next } from "../types.ts";
 import type { UpdaterCtx } from "./types.ts";

--- a/store/persist.ts
+++ b/store/persist.ts
@@ -26,16 +26,15 @@ interface TransformFunctions<S extends AnyState> {
   out(s: Partial<S>): Operation<Partial<S>>;
 }
 
-export function createTransform<S extends AnyState>(initialState: Partial<S>) {
-  const state = initialState;
+export function createTransform<S extends AnyState>(inputState: Partial<S>) {
 
   const transformers: TransformFunctions<S> = {
-    in: function* (_: Partial<S>): Operation<Partial<S>> {
-      return state;
+    in: function* (currentState: Partial<S>): Operation<Partial<S>> {
+      return currentState;
 
     },
-    out: function* (_: Partial<S>): Operation<Partial<S>> {
-      return state;
+    out: function* (currentState: Partial<S>): Operation<Partial<S>> {
+      return currentState;
     }
   };
   const setInTransformer = function (transformer: (fn: Partial<S>) => Operation<Partial<S>>): void {

--- a/store/persist.ts
+++ b/store/persist.ts
@@ -1,5 +1,5 @@
-import { call, Err, Ok, Operation, Result } from '../deps.ts';
-import { select, updateStore } from './fx.ts';
+import { call, Err, Ok, Operation, Result } from "../deps.ts";
+import { select, updateStore } from "./fx.ts";
 
 import type { AnyState, Next } from "../types.ts";
 import type { UpdaterCtx } from "./types.ts";

--- a/test/persist.test.ts
+++ b/test/persist.test.ts
@@ -1,16 +1,14 @@
-import { asserts, describe, it } from "../test.ts";
+import { sleep } from '../deps.ts';
+import { Ok, Operation, parallel, put, take } from '../mod.ts';
 import {
-  createPersistor,
-  createSchema,
-  createStore,
-  PERSIST_LOADER_ID,
-  PersistAdapter,
-  persistStoreMdw,
-  slice,
-} from "../store/mod.ts";
-import { Ok, Operation, parallel, put, take } from "../mod.ts";
+    createPersistor, createSchema, createStore, createTransform, PERSIST_LOADER_ID, PersistAdapter,
+    persistStoreMdw, slice
+} from '../store/mod.ts';
+import { asserts, describe, it } from '../test.ts';
+import { LoaderItemState } from '../types.ts';
 
 const tests = describe("store");
+
 
 it(tests, "can persist to storage adapters", async () => {
   const [schema, initialState] = createSchema({
@@ -97,3 +95,268 @@ it(tests, "rehydrates state", async () => {
     "123",
   );
 });
+
+it(tests, "persists inbound state using transform 'in' function", async () => {
+  const [schema, initialState] = createSchema({
+    token: slice.str(),
+    loaders: slice.loaders(),
+    cache: slice.table({ empty: {} }),
+  });
+  type State = typeof initialState;
+  let ls = "{}";
+
+  const adapter: PersistAdapter<State> = {
+    getItem: function* (_: string) {
+      return Ok(JSON.parse(ls));
+    },
+    setItem: function* (_: string, s: Partial<State>) {
+      ls = JSON.stringify(s);
+      return Ok(undefined);
+    },
+    removeItem: function* (_: string) {
+      return Ok(undefined);
+    },
+  };
+  
+  const transform = createTransform<State>(initialState);
+
+  transform.in= (state: State) => {
+    return { ...state, token: state.token.split("").reverse().join("") };
+  };
+
+  const persistor = createPersistor<State>({
+    adapter,
+    allowlist: ["token", "cache"], 
+    transform
+  });
+
+  const mdw = persistStoreMdw(persistor);
+  const store = createStore({
+    initialState,
+    middleware: [mdw],
+  });
+
+  await store.run(function* (): Operation<void> {
+    yield* persistor.rehydrate();
+
+    const group = yield* parallel([
+      function* (): Operation<void> {
+        const action = yield* take<string>("SET_TOKEN");
+        yield* schema.update(schema.token.set(action.payload));
+      },
+      function* () {
+        yield* put({ type: "SET_TOKEN", payload: "1234" });
+      },
+    ]);
+    yield* group;
+  });
+  asserts.assertEquals(
+    ls,
+    '{"token":"4321","cache":{}}', 
+  );
+});
+
+
+it(tests, "persists inbound state using tranform setInTransformer", async () => {
+  const [schema, initialState] = createSchema({
+    token: slice.str(),
+    loaders: slice.loaders(),
+    cache: slice.table({ empty: {} }),
+  });
+  type State = typeof initialState;
+  let ls = "{}";
+
+  const adapter: PersistAdapter<State> = {
+    getItem: function* (_: string) {
+      return Ok(JSON.parse(ls));
+    },
+    setItem: function* (_: string, s: Partial<State>) {
+      ls = JSON.stringify(s);
+      return Ok(undefined);
+    },
+    removeItem: function* (_: string) {
+      return Ok(undefined);
+    },
+  };
+  
+
+  function revertToken(state: State): Partial<State> {
+    return { ...state, token: state.token.split("").reverse().join("") };
+  }
+  const transform = createTransform<State>(initialState);
+  transform.setInTransformer(revertToken);
+
+
+  const persistor = createPersistor<State>({
+    adapter,
+    allowlist: ["token", "cache"],
+    transform
+  });
+
+  const mdw = persistStoreMdw(persistor);
+  const store = createStore({
+    initialState,
+    middleware: [mdw],
+  });
+
+  await store.run(function* (): Operation<void> {
+    yield* persistor.rehydrate();
+
+    const group = yield* parallel([
+      function* (): Operation<void> {
+        const action = yield* take<string>("SET_TOKEN");
+        yield* schema.update(schema.token.set(action.payload));
+      },
+      function* () {
+        yield* put({ type: "SET_TOKEN", payload: "1234" });
+      },
+    ]);
+    yield* group;
+  });
+  asserts.assertEquals(
+    ls,
+    '{"token":"4321","cache":{}}', 
+  );
+});
+
+it(tests, "persists a filtered nested part of a slice", async () => {
+  const [schema, initialState] = createSchema({
+    token: slice.str(),
+    loaders: slice.loaders(),
+    cache: slice.table({ empty: {} }),
+  });
+  type State = typeof initialState;
+  let ls = "{}";
+
+  const adapter: PersistAdapter<State> = {
+    getItem: function* (_: string) {
+      return Ok(JSON.parse(ls));
+    },
+    setItem: function* (_: string, s: Partial<State>) {
+      ls = JSON.stringify(s);
+      return Ok(undefined);
+    },
+    removeItem: function* (_: string) {
+      return Ok(undefined);
+    },
+  };
+
+ 
+  function pickLatestOfLoadersAandC(state: State): Partial<State> {
+    const nextState = { ...state }; 
+  
+    if (state.loaders) {
+      const maxLastRun: Record<string, number> = {}; 
+      const entryWithMaxLastRun: Record<string, LoaderItemState<any>> = {}; 
+  
+      for (const entryKey in state.loaders) {
+        const entry = state.loaders[entryKey] as LoaderItemState<any>;
+        const sliceName = entryKey.split("|")[0].trim(); 
+        if (sliceName.includes('A') || sliceName.includes('C')) {          
+          if (!maxLastRun[sliceName] || entry.lastRun > maxLastRun[sliceName]) {
+            maxLastRun[sliceName] = entry.lastRun;
+            entryWithMaxLastRun[sliceName] = entry; 
+          }
+        }
+      }
+      nextState.loaders = entryWithMaxLastRun; 
+    }
+    return nextState;
+  }
+  
+
+  const transform = createTransform<State>(initialState);
+  transform.setInTransformer(pickLatestOfLoadersAandC);
+
+  const persistor = createPersistor<State>({
+    adapter,
+    transform
+  });
+
+  const mdw = persistStoreMdw(persistor);
+  const store = createStore({
+    initialState,
+    middleware: [mdw],
+  });
+
+  await store.run(function* (): Operation<void> {
+    yield* persistor.rehydrate();
+    const group = yield* parallel([
+      function* () {
+        yield* schema.update(schema.token.set("1234"));
+        yield* schema.update(schema.loaders.start({ id: "A [POST]|1234", message: "loading A-first" }));
+        yield* schema.update(schema.loaders.start({ id: "B" }));
+        yield* schema.update(schema.loaders.start({ id: "C" }));
+        yield* sleep(300);
+        yield* schema.update(schema.loaders.success({ id: "A" }));
+        yield* schema.update(schema.loaders.success({ id: "B" }));
+        yield* schema.update(schema.loaders.success({ id: "C" }));
+        yield* schema.update(schema.loaders.start({ id: "A [POST]|5678", message: "loading A-second" }));
+        yield* schema.update(schema.loaders.start({ id: "B" }));
+        yield* schema.update(schema.loaders.start({ id: "C" }));
+        yield* sleep(300);
+        yield* schema.update(schema.loaders.success({ id: "A" }));
+        yield* schema.update(schema.loaders.success({ id: "B" }));
+        yield* schema.update(schema.loaders.success({ id: "C" }));
+        yield* schema.update(schema.token.set("1"));
+      },
+    ]);
+    yield* group;
+  });
+  asserts.assertStringIncludes(
+    ls,
+    '{"token":"1"', 
+  );
+  asserts.assertStringIncludes(
+    ls,
+    '"message":"loading A-second"',
+  );
+  asserts.assertStringIncludes(
+    ls,
+    '"id":"C"',
+  );
+   asserts.assertNotMatch(
+    ls,
+    /"message":"loading A-first"/,
+  );
+  asserts.assertNotMatch(
+    ls,
+    /"id":"B"/,
+  );
+});
+
+// todo: implement these tests
+
+
+// it(tests, "persists as it is, without any transformer", async () => {
+//  prooven by the other tests
+// });
+
+it(tests, "handles the empty state correctly", async () => {});
+it(tests, "handles errors gracefully", async () => {});
+//it(tests, "applies the transformer before persisting state" , async () => {});
+
+// related to allowlist (if we transform/derive using the value of a slice that is not in the allow list)
+// it(tests, "the tranformers are applied to the full state, regardless of the allowlist", async () => {});
+
+
+
+// it("the inbound transformer can be reset during runtime", async () => {
+//   asserts.assertEquals(1, 1);
+// });
+
+// it("persists state using transform 'out' function", async () => {
+//   asserts.assertEquals(1, 1);
+// });
+
+// it("persists outbound state using tranform setOutTransformer", async () => {
+//   asserts.assertEquals(1, 1);
+// });
+
+// it("persists outbound a filtered nested part of a slice", async () => {
+//   asserts.assertEquals(1, 1);
+// });
+
+// it("the outbound transformer can be reset during runtime", async () => {
+//   asserts.assertEquals(1, 1);
+// });

--- a/test/persist.test.ts
+++ b/test/persist.test.ts
@@ -509,10 +509,64 @@ it(
   },
 );
 
-// it(tests, "applies the transformer before persisting state" , async () => {});
+it(
+  tests,
+  "allowdList is filtered out after the inbound  transformer is applied",
+  async () => {
+    const [schema, initialState] = createSchema({
+      token: slice.str(),
+      counter: slice.num(0),
+      loaders: slice.loaders(),
+      cache: slice.table({ empty: {} }),
+    });
+    type State = typeof initialState;
+    let ls = "{}";
+    const adapter: PersistAdapter<State> = {
+      getItem: function* (_: string) {
+        return Ok(JSON.parse(ls));
+      },
+      setItem: function* (_: string, s: Partial<State>) {
+        ls = JSON.stringify(s);
+        return Ok(undefined);
+      },
+      removeItem: function* (_: string) {
+        return Ok(undefined);
+      },
+    };
 
-// related to allowlist (if we transform/derive using the value of a slice that is not in the allow list)
-// it(tests, "the tranformers are applied to the full state, regardless of the allowlist", async () => {});
+    const transform = createTransform<State>();
+    transform.setInTransformer(function* (state) {
+      return {
+        ...state,
+        token: `${state.counter}${state?.token?.split("").reverse().join("")}`,
+      };
+    });
+
+    const persistor = createPersistor<State>({
+      adapter,
+      allowlist: ["token"],
+      transform,
+    });
+
+    const mdw = persistStoreMdw(persistor);
+    const store = createStore({
+      initialState,
+      middleware: [mdw],
+    });
+
+    await store.run(function* (): Operation<void> {
+      yield* persistor.rehydrate();
+      yield* schema.update(schema.loaders.success({ id: PERSIST_LOADER_ID }));
+      yield* schema.update(schema.token.set("1234"));
+      yield* schema.update(schema.counter.set(5));
+    });
+
+    asserts.assertEquals(
+      ls,
+      '{"token":"54321"}',
+    );
+  },
+);
 
 // it("the inbound transformer can be reset during runtime", async () => {
 //   asserts.assertEquals(1, 1);

--- a/test/persist.test.ts
+++ b/test/persist.test.ts
@@ -450,9 +450,6 @@ it(
       yield* group;
     });
 
-    console.log("local state:", ls);
-    console.log("store:", store.getState());
-
     asserts.assertEquals(
       ls,
       '{"token":"1234"}',

--- a/test/persist.test.ts
+++ b/test/persist.test.ts
@@ -332,8 +332,8 @@ it(tests, "persists a filtered nested part of a slice", async () => {
 //  prooven by the other tests
 // });
 
-it(tests, "handles the empty state correctly", async () => {});
-it(tests, "handles errors gracefully", async () => {});
+// it(tests, "handles the empty state correctly", async () => {});
+// it(tests, "handles errors gracefully", async () => {});
 //it(tests, "applies the transformer before persisting state" , async () => {});
 
 // related to allowlist (if we transform/derive using the value of a slice that is not in the allow list)

--- a/test/persist.test.ts
+++ b/test/persist.test.ts
@@ -568,9 +568,74 @@ it(
   },
 );
 
-// it("the inbound transformer can be reset during runtime", async () => {
-//   asserts.assertEquals(1, 1);
-// });
+it("the inbound transformer can be redifined during runtime", async () => {
+  const [schema, initialState] = createSchema({
+    token: slice.str(),
+    loaders: slice.loaders(),
+    cache: slice.table({ empty: {} }),
+  });
+  type State = typeof initialState;
+  let ls = "{}";
+  const adapter: PersistAdapter<State> = {
+    getItem: function* (_: string) {
+      return Ok(JSON.parse(ls));
+    },
+    setItem: function* (_: string, s: Partial<State>) {
+      ls = JSON.stringify(s);
+      return Ok(undefined);
+    },
+    removeItem: function* (_: string) {
+      return Ok(undefined);
+    },
+  };
+
+  const transform = createTransform<State>();
+  transform.setInTransformer(function* (state) {
+    return {
+      ...state,
+      token: `${state?.token?.split("").reverse().join("")}`,
+    };
+  });
+
+  const persistor = createPersistor<State>({
+    adapter,
+    allowlist: ["token"],
+    transform,
+  });
+
+  const mdw = persistStoreMdw(persistor);
+  const store = createStore({
+    initialState,
+    middleware: [mdw],
+  });
+
+  await store.run(function* (): Operation<void> {
+    yield* persistor.rehydrate();
+    yield* schema.update(schema.loaders.success({ id: PERSIST_LOADER_ID }));
+    yield* schema.update(schema.token.set("01234"));
+  });
+
+  asserts.assertEquals(
+    ls,
+    '{"token":"43210"}',
+  );
+
+  transform.setInTransformer(function* (state) {
+    return {
+      ...state,
+      token: `${state?.token}56789`,
+    };
+  });
+
+  await store.run(function* (): Operation<void> {
+    yield* schema.update(schema.token.set("01234"));
+  });
+
+  asserts.assertEquals(
+    ls,
+    '{"token":"0123456789"}',
+  );
+});
 
 // it("persists state using transform 'out' function", async () => {
 //   asserts.assertEquals(1, 1);

--- a/test/persist.test.ts
+++ b/test/persist.test.ts
@@ -808,6 +808,75 @@ it(tests, "persists outbound a filtered nested part of a slice", async () => {
   );
 });
 
-// it("the outbound transformer can be reset during runtime", async () => {
-//   asserts.assertEquals(1, 1);
-// });
+it("the outbound transformer can be reset during runtime", async () => {
+  const [schema, initialState] = createSchema({
+    token: slice.str(),
+    counter: slice.num(0),
+    loaders: slice.loaders(),
+    cache: slice.table({ empty: {} }),
+  });
+  type State = typeof initialState;
+  let ls = '{"token": "01234"}';
+
+  const adapter: PersistAdapter<State> = {
+    getItem: function* (_: string) {
+      return Ok(JSON.parse(ls));
+    },
+    setItem: function* (_: string, s: Partial<State>) {
+      ls = JSON.stringify(s);
+      return Ok(undefined);
+    },
+    removeItem: function* (_: string) {
+      return Ok(undefined);
+    },
+  };
+
+  function* revertToken(state: Partial<State>) {
+    return { ...state, token: state?.token?.split("").reverse().join("") };
+  }
+  const transform = createTransform<State>();
+  transform.out = revertToken;
+
+  const persistor = createPersistor<State>({
+    adapter,
+    allowlist: ["token"],
+    transform,
+  });
+
+  const mdw = persistStoreMdw(persistor);
+  const store = createStore({
+    initialState,
+    middleware: [mdw],
+  });
+
+  await store.run(function* (): Operation<void> {
+    yield* persistor.rehydrate();
+    yield* schema.update(schema.loaders.success({ id: PERSIST_LOADER_ID }));
+  });
+
+  asserts.assertEquals(
+    store.getState().token,
+    "43210",
+  );
+
+  transform.out = function* (state) {
+    return {
+      ...state,
+      token: `${state?.token}56789`,
+    };
+  };
+
+  await store.run(function* (): Operation<void> {
+    yield* schema.update(schema.token.set("01234"));
+  });
+
+  asserts.assertEquals(
+    ls,
+    '{"token":"0123456789"}',
+  );
+
+  asserts.assertEquals(
+    store.getState().token,
+    "0123456789",
+  );
+});

--- a/test/persist.test.ts
+++ b/test/persist.test.ts
@@ -327,19 +327,18 @@ it(tests, "persists a filtered nested part of a slice", async () => {
 
 // todo: implement these tests
 
-
 // it(tests, "persists as it is, without any transformer", async () => {
 //  prooven by the other tests
 // });
 
 // it(tests, "handles the empty state correctly", async () => {});
+
 // it(tests, "handles errors gracefully", async () => {});
-//it(tests, "applies the transformer before persisting state" , async () => {});
+
+// it(tests, "applies the transformer before persisting state" , async () => {});
 
 // related to allowlist (if we transform/derive using the value of a slice that is not in the allow list)
 // it(tests, "the tranformers are applied to the full state, regardless of the allowlist", async () => {});
-
-
 
 // it("the inbound transformer can be reset during runtime", async () => {
 //   asserts.assertEquals(1, 1);


### PR DESCRIPTION
This PR introduces:

Custom Transform Functions: Allows users to define inbound and outbound state transformations during persistence.
Integration with Persistence Workflow: Ensures that state transformations are applied when saving to and loading from storage.
Error Handling for Transformers: Adds error handling for transform functions with fallback to identity transformations.